### PR TITLE
Update CAPI v2 docs links to new subdomain

### DIFF
--- a/http-routes/020-route-propagation-pt-0.markdown
+++ b/http-routes/020-route-propagation-pt-0.markdown
@@ -51,7 +51,7 @@ to store these values in a doc outside of tracker.
 
 ## Resources for the entire route propagation track
 **Cloud Controller**
-* [Cloud Controller V2 API docs](https://apidocs.cloudfoundry.org)
+* [Cloud Controller V2 API docs](https://v2-apidocs.cloudfoundry.org)
 * [Cloud Controller V3 API docs](http://v3-apidocs.cloudfoundry.org)
 
 **Diego**

--- a/http-routes/070-incoming-http-requests-pt-0.markdown
+++ b/http-routes/070-incoming-http-requests-pt-0.markdown
@@ -43,7 +43,7 @@ for your to record these values so you can store them.
 
 ## Resources for the entire route propagation track
 **Cloud Controller**
-* [Cloud Controller V2 API docs](https://apidocs.cloudfoundry.org)
+* [Cloud Controller V2 API docs](https://v2-apidocs.cloudfoundry.org)
 * [Cloud Controller V3 API docs](http://v3-apidocs.cloudfoundry.org)
 
 **Diego**


### PR DESCRIPTION
This PR updates CAPI v2 docs links from `apidocs.cloudfoundry.org` to `v2-apidocs.cloudfoundry.org`.
The goal is to signal that v3 is the primary API, also a necessary step in eventually sunsetting v2.

~~The infrastructure hosting the app serving docs at apidocs.cloudfoundry.org is expected to go down imminently, so this change is needed to avoid dead links.~~
`apidocs.cloudfoundry.org` has been converted to a redirect to `v3-apidocs.cloudfoundry.org`, so this change is needed to avoid incorrect links

See capi-release PRs [#440](https://github.com/cloudfoundry/capi-release/pull/440) and [#441](https://github.com/cloudfoundry/capi-release/pull/441)