### PR TITLE
fix: Route Integrity/Misrouting Docs link

### DIFF
--- a/http-routes/020-route-propagation-pt-0.markdown
+++ b/http-routes/020-route-propagation-pt-0.markdown
@@ -71,7 +71,7 @@ to store these values in a doc outside of tracker.
 * [iptables man page](http://ipset.netfilter.org/iptables.man.html)
 
 **Route Integrity**
-* [Route Integrity/Misrouting Docs](https://docs.cloudfoundry.org/concepts/http-routing.html#-preventing-misrouting)
+* [Route Integrity/Misrouting Docs](https://docs.cloudfoundry.org/concepts/http-routing.html#consistency)
 
 **Envoy**
 * [What is Envoy?](https://www.envoyproxy.io/docs/envoy/latest/intro/what_is_envoy)

--- a/http-routes/070-incoming-http-requests-pt-0.markdown
+++ b/http-routes/070-incoming-http-requests-pt-0.markdown
@@ -63,7 +63,7 @@ for your to record these values so you can store them.
 * [iptables man page](http://ipset.netfilter.org/iptables.man.html)
 
 **Route Integrity**
-* [Route Integrity/Misrouting Docs](https://docs.cloudfoundry.org/concepts/http-routing.html#-preventing-misrouting)
+* [Route Integrity/Misrouting Docs](https://docs.cloudfoundry.org/concepts/http-routing.html#consistency)
 
 **Envoy**
 * [What is Envoy?](https://www.envoyproxy.io/docs/envoy/latest/intro/what_is_envoy)

--- a/http-routes/110-incoming-http-requests-pt-4.markdown
+++ b/http-routes/110-incoming-http-requests-pt-4.markdown
@@ -120,5 +120,5 @@ We made it! We finally made it to the end! Everything is set up and someone can 
 Look at the Envoy's 8080 listener and related cluster and see how network traffic is sent to the app.
 
 ## Resources
-* [Route Integrity/Misrouting Docs](https://docs.cloudfoundry.org/concepts/http-routing.html#-preventing-misrouting)
+* [Route Integrity/Misrouting Docs](https://docs.cloudfoundry.org/concepts/http-routing.html#consistency)
 * [What is Envoy?](https://www.envoyproxy.io/docs/envoy/latest/intro/what_is_envoy)


### PR DESCRIPTION
The link points to an incorrect resource.