### PR TITLE
fix: use MySQL client from percona

### DIFF
--- a/c2c/120-dataflow-pt-7.markdown
+++ b/c2c/120-dataflow-pt-7.markdown
@@ -86,9 +86,9 @@ at the ARP table.
    `silk-controller.properties.database.password`. You might need to look up
    these values in credhub. This will differ based on your deployment.
 1. Bosh ssh onto the database VM and become root.
-1. Login to your database. For a pxc-mysql deployment, it looks like this
+1. Login to your database. For a percona-xxx deployment, it looks like this
    ```bash
-   /var/vcap/packages/pxc/bin/mysql -u network_connectivity -p -h sql-db.service.cf.internal -D DATABASE_NAME
+   /var/vcap/packages/percona-xtradb-cluster-5.7/bin/mysql -u network_connectivity -p -h sql-db.service.cf.internal -D DATABASE_NAME
    ```
 1. Run the following query to look at all of the subnets.
    ```

--- a/c2c/120-dataflow-pt-7.markdown
+++ b/c2c/120-dataflow-pt-7.markdown
@@ -86,9 +86,9 @@ at the ARP table.
    `silk-controller.properties.database.password`. You might need to look up
    these values in credhub. This will differ based on your deployment.
 1. Bosh ssh onto the database VM and become root.
-1. Login to your database. For a percona-xtradb-cluster-x.x deployment, it looks like this
+1. Login to your database. For a percona-xtradb-cluster-8.0 deployment, it looks like this
    ```bash
-   /var/vcap/packages/percona-xtradb-cluster-5.7/bin/mysql -u network_connectivity -p -h sql-db.service.cf.internal -D DATABASE_NAME
+   /var/vcap/packages/percona-xtradb-cluster-8.0/bin/mysql -u network_connectivity -p -h sql-db.service.cf.internal -D DATABASE_NAME
    ```
 1. Run the following query to look at all of the subnets.
    ```

--- a/c2c/120-dataflow-pt-7.markdown
+++ b/c2c/120-dataflow-pt-7.markdown
@@ -86,7 +86,7 @@ at the ARP table.
    `silk-controller.properties.database.password`. You might need to look up
    these values in credhub. This will differ based on your deployment.
 1. Bosh ssh onto the database VM and become root.
-1. Login to your database. For a percona-xxx deployment, it looks like this
+1. Login to your database. For a percona-xtradb-cluster-x.x deployment, it looks like this
    ```bash
    /var/vcap/packages/percona-xtradb-cluster-5.7/bin/mysql -u network_connectivity -p -h sql-db.service.cf.internal -D DATABASE_NAME
    ```


### PR DESCRIPTION
`pxc-mysql` is no longer available.
Available packages:

```
$ /var/vcap/packages/
auto-tune-mysql/            bpm/                        galera-init/                percona-xtrabackup-8.0/     prom_scraper/               pxc-gra-log-purger/         routing_utils/              
bootstrap/                  forwarder-agent/            loggregator_agent/          percona-xtradb-cluster-5.7/ proxy/                      pxc-utils/                  syslog-agent/               
bosh-dns/                   galera-agent/               percona-xtrabackup-2.4/     percona-xtradb-cluster-8.0/ pxc-cluster-health-logger/  route_registrar/            
```